### PR TITLE
docs: use /etc/apt/keyrings for repository key installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,11 @@ This is an unofficial community project providing **the most up-to-date versions
 ### Add the repository to your sources.list
 
 ```bash
-# Add repository GPG key
-curl -sS https://debian.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/debian.griffo.io.gpg
-
-# Add repository to sources
-echo "deb https://debian.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/debian.griffo.io.list
-
-# Update package list
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://debian.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc \
+  | sudo gpg --dearmor --yes -o /etc/apt/keyrings/debian.griffo.io.gpg
+echo "deb [signed-by=/etc/apt/keyrings/debian.griffo.io.gpg] https://debian.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" \
+  | sudo tee /etc/apt/sources.list.d/debian.griffo.io.list > /dev/null
 sudo apt update
 ```
 


### PR DESCRIPTION
Hi! Thanks for maintaining this repository — I use it across several Debian and Ubuntu systems and it has real value for staying current with properly packaged software while avoiding the technical debt of non-distro package managers.

This PR is intentionally small and docs-only: it updates the README installation example so the repository key is stored in `/etc/apt/keyrings` and referenced with `signed-by=`, rather than placing it in `/etc/apt/trusted.gpg.d/`.

Why this change:

- Modern APT guidance recommends using `Signed-By` for repository-specific trust.
- For keys not managed by packages, `/etc/apt/keyrings` is the recommended location.
- This is the direction documented by both Debian and Ubuntu APT manpages.
- It helps security-focused and agentic or automated workflows consume the repository without tripping over a deviation from current best practice.

An additional security rationale is trust scoping:

When a third-party key is added to the global APT trust store, it is no longer just trusted for that one repository. Debian's third-party repository guidance notes that using the global SecureApt trust anchor can cause the system to accept signatures from that third-party key on other repositories that do not use `signed-by=`. In other words, the issue is not only deprecation or style — it is also about avoiding unnecessarily broad trust.

Using `/etc/apt/keyrings` together with `signed-by=` keeps the trust relationship tied to this repository specifically, which is a much better fit for modern Debian and Ubuntu security practice.

As more development environments are being assembled and maintained by automated or agentic workflows, keeping repository trust narrowly scoped is increasingly important: it reduces avoidable warnings, aligns with current platform guidance, and provides a safer default foundation for automated package consumption.

The functional behavior remains the same for users, but the instructions become more aligned with current Debian and Ubuntu conventions and easier to adopt in hardened, security-conscious, or automated environments.

Thanks again for the repo — it's a genuinely useful way to keep evergreen developer tooling available as native Debian and Ubuntu packages.